### PR TITLE
Compile error looking for WiFiData.h

### DIFF
--- a/arduino/libretuya/api/WiFi/WiFi.h
+++ b/arduino/libretuya/api/WiFi/WiFi.h
@@ -29,7 +29,7 @@
 
 #include "WiFiType.h"
 // family's data structure
-#include <WiFiData.h>
+#include "WiFiData.h"
 
 class WiFiClass {
   public:

--- a/arduino/libretuya/api/WiFi/WiFiData.h
+++ b/arduino/libretuya/api/WiFi/WiFiData.h
@@ -1,0 +1,22 @@
+/* Copyright (c) Kuba Szczodrzyński 2022-06-23. */
+
+#pragma once
+
+#include <Arduino.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <FreeRTOS.h>
+#include <semphr.h>
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+typedef struct {
+	bool initialized;
+	bool sleep;
+	SemaphoreHandle_t scanSem;
+} WiFiData;


### PR DESCRIPTION
When compiling 'hello world' with beken-72xx-arduino framework, compile would fail with the following:
`.platformio/platforms/libretuya/arduino/libretuya/api/WiFi/WiFi.h:32:22: fatal error: WiFiData.h: No such file or directory`

File was not present in repository.

Copied WiFiData.h from arduino/realtek-ambz/libraries/WiFi/WiFiData.h
Changed include for WiFiData.h from  <> to ""

Compile now completes.
