### PR TITLE
[realtek-ambz] Fix 4M/980k linker script name

### DIFF
--- a/boards/_base/realtek-ambz-4mb-980k.json
+++ b/boards/_base/realtek-ambz-4mb-980k.json
@@ -1,7 +1,7 @@
 {
 	"build": {
-		"ldscript_sdk": "rlx8711B-symbol-v02-img2_xip1_4M_cpp.ld",
-		"ldscript_arduino": "rlx8711B-symbol-v02-img2_xip1_4M_cpp.ld",
+		"ldscript_sdk": "rlx8711B-symbol-v02-img2_xip1_4M_980k_cpp.ld",
+		"ldscript_arduino": "rlx8711B-symbol-v02-img2_xip1_4M_980k_cpp.ld",
 		"amb_boot_all": "boot_all_C556.bin"
 	},
 	"flash": {


### PR DESCRIPTION
The ld files are named rlx8711B-symbol-v02-img2_xip1_4M_980k_cpp.ld and rlx8711B-symbol-v02-img2_xip2_4M_980k_cpp.ld but they are referenced as rlx8711B-symbol-v02-img2_xip1_4M_cpp.ld