### PR TITLE
[beken-72xx] Fix for flicker when PWM lights turn on/off on bk7231n

### DIFF
--- a/arduino/beken-72xx/cores/arduino/wiring_analog.c
+++ b/arduino/beken-72xx/cores/arduino/wiring_analog.c
@@ -106,7 +106,7 @@ void analogWrite(pin_size_t pinNumber, int value) {
 	pwm.duty_cycle3 = 0;
 #endif
 
-	if (value) {
+	if (dutyCycle) {
 		if (!pinEnabled(pin, PIN_PWM)) {
 			// enable PWM and set its value
 			pwm.cfg.bits.en		= PWM_ENABLE;
@@ -131,7 +131,6 @@ void analogWrite(pin_size_t pinNumber, int value) {
 			// disable PWM
 			pwm.cfg.bits.en = PWM_DISABLE;
 			__wrap_bk_printf_disable();
-			sddev_control(PWM_DEV_NAME, CMD_PWM_SET_DUTY_CYCLE, &pwm);
 			sddev_control(PWM_DEV_NAME, CMD_PWM_DEINIT_PARAM, &pwm);
 			__wrap_bk_printf_enable();
 			pin->enabled &= ~PIN_PWM;


### PR DESCRIPTION
Some of my BK7231N RGBWW bulbs were occasionally flickering when they turned on/off with libretuya-esphome.  This was more noticeable at higher PWM frequencies.  I discovered that when the pwm dutycycle value is set to 0 then the output goes high.  This doesn't seem to affect my BK7231T based bulbs.